### PR TITLE
Re-factor Edit, Confirm, and Image Dialogs using Base Dialog component

### DIFF
--- a/src/Dialog/Confirmation/ConfirmationDialog.stories.tsx
+++ b/src/Dialog/Confirmation/ConfirmationDialog.stories.tsx
@@ -1,30 +1,51 @@
-// Import Storybook.
-import type { Meta, StoryObj } from '@storybook/react';
-
-// Import Component and related types.
+import React from 'react'; // Make sure React is imported if needed by your ESLint rules
+import { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import ConfirmationDialogComponent, { ConfirmationDialogProps } from './ConfirmationDialog';
-import React from 'react';
-// Configure Metadata.
-const meta: Meta = {
+import { Button } from '@mui/material';
+
+const meta: Meta<ConfirmationDialogProps> = {
   title: 'Dialog/ConfirmationDialog',
   component: ConfirmationDialogComponent,
-  tags: ['autodocs'],
   argTypes: {
-    height: { control: 'text' },
+    onClose: { action: 'Dialog closed' },
+    onConfirm: { action: 'Action confirmed' },
+    ButtonComponent: {
+      table: {
+        disable: true
+      },
+      control: {
+        type: null
+      }
+    },
+    ButtonProps: {
+      control: 'object'
+    }
   },
   parameters: {
-    componentSubtitle: 'A Sample Component',
+    componentSubtitle: 'A confirmation dialog component for critical user actions.',
     docs: {
       description: {
-        component: 'This component is meant to illustrate how to effectively document components.',
-      },
+        component: 'This component is designed to confirm user actions, such as deletions or updates, using a customizable dialog.'
+      }
     },
-    references: [],
-  },
+  }
 };
-export default meta;
-type Story = StoryObj<typeof meta>;
 
-// Configure Component Stories.
-export const ConfirmationDialog: Story = (args: ConfirmationDialogProps) => <ConfirmationDialogComponent {...args} />;
-ConfirmationDialog.args = {};
+export default meta;
+
+// Default story for the ConfirmationDialog
+export const Default: StoryObj<ConfirmationDialogProps> = {
+  args: {
+    onClose: action('Dialog closed'),
+    onConfirm: action('Action confirmed'),
+    title: 'Are you sure?',
+    content: 'Do you want to perform this action? It cannot be undone.',
+    ButtonComponent: ({ onClick }) => (
+      <Button onClick={onClick} color="primary">
+        Open Confirmation Dialog
+      </Button>
+    ),
+    ButtonProps: {}
+  }
+};

--- a/src/Dialog/Confirmation/ConfirmationDialog.tsx
+++ b/src/Dialog/Confirmation/ConfirmationDialog.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import React from 'react';
-import Dialog, { CommonDialogProps } from '../Dialog'; // Adjust the import path as necessary
+import Dialog, { CommonDialogProps } from '../Dialog';
 
 export type ConfirmationDialogProps = CommonDialogProps & {
   content: string;
@@ -8,8 +10,27 @@ export type ConfirmationDialogProps = CommonDialogProps & {
   ButtonProps: any;
 };
 
-const ConfirmationDialog: React.FC<ConfirmationDialogProps> = (props) => {
-  return <Dialog {...props} />;
+const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
+  onClose,
+  title,
+  sx,
+  content,
+  onConfirm,
+  ButtonComponent,
+  ButtonProps
+}) => {
+  // Pass only the necessary handlers and content to the Dialog component
+  return (
+    <Dialog
+      onClose={onClose}
+      title={title}
+      sx={sx}
+      content={content}
+      onConfirm={onConfirm}
+      ButtonComponent={ButtonComponent}
+      ButtonProps={ButtonProps}
+    />
+  );
 };
 
 export default ConfirmationDialog;

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -29,6 +29,10 @@ const Dialog: React.FC<DialogProps> = ({ onClose, onConfirm, title, content, But
     setDialogOpen(false);
     onClose();
   }
+
+  function handleCancel() {
+    handleClose();
+  }
   return (
     <>
       <ButtonComponent
@@ -51,7 +55,7 @@ const Dialog: React.FC<DialogProps> = ({ onClose, onConfirm, title, content, But
         </DialogContent>
         {onConfirm && (
           <DialogActions sx={{ justifyContent: 'center' }}>
-            <Button onClick={onClose}>Cancel</Button>
+            <Button onClick={handleCancel}>Cancel</Button>
             <Button
               onClick={() => {
                 setDialogOpen(false);

--- a/src/Dialog/Edit/EditDialog.stories.tsx
+++ b/src/Dialog/Edit/EditDialog.stories.tsx
@@ -1,33 +1,37 @@
-// Import Storybook.
-import type { Meta, StoryObj } from '@storybook/react';
-
-// Import Component and related types.
-import EditDialogComponent, { EditDialogProps } from './EditDialog';
 import React from 'react';
-// Configure Metadata.
-const meta: Meta = {
+import { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import EditDialog, { EditDialogProps } from './EditDialog';
+import { Button } from '@mui/material';
+
+const meta: Meta<EditDialogProps> = {
   title: 'Dialog/EditDialog',
-  component: EditDialogComponent,
-  tags: ['autodocs'],
+  component: EditDialog,
   argTypes: {
-    height: { control: 'text' },
+    onClose: { action: 'Dialog closed' },
+    onConfirm: { action: 'Edit confirmed' },
   },
   parameters: {
-    componentSubtitle: 'A Sample Component',
     docs: {
       description: {
-        component: 'This component is meant to illustrate how to effectively document components.',
+        component: 'EditDialog allows editing of various fields within a dialog window.',
       },
     },
-    references: [],
   },
 };
-export default meta;
-type Story = StoryObj<typeof meta>;
 
-// Configure Component Stories.
-export const EditDialog: Story = (args: EditDialogProps) => <EditDialogComponent {...args} />;
-EditDialog.args = {
-  toEdit: {},
-  onClose: () => console.log('Close action'),
+export default meta;
+
+export const Default: StoryObj<EditDialogProps> = {
+  args: {
+    onClose: action('Dialog closed'),
+    onConfirm: action('Edit confirmed'),
+    title: 'Edit User Details',
+    fields: {
+      name: { value: 'John Doe', validation: (value) => value.trim().length > 0 },
+      age: { value: 30, validation: (value) => !isNaN(value) && value > 0 },
+    },
+    ButtonComponent: ({ onClick }) => <Button onClick={onClick} color="primary">Open Edit Dialog</Button>,
+    ButtonProps: {}
+  }
 };

--- a/src/Dialog/Edit/EditDialog.tsx
+++ b/src/Dialog/Edit/EditDialog.tsx
@@ -2,51 +2,70 @@
 
 import { Box } from '@mui/system';
 import React, { useState, useEffect } from 'react';
-import { CommonDialogProps } from '../Dialog';
+import Dialog, { CommonDialogProps } from '../Dialog';
 
 export type EditDialogProps = CommonDialogProps & {
   fields: {
     [key: string]: { value: string | number | boolean; validation?: (value: string | number | boolean) => boolean };
   };
-  onClose: () => void;
+  ButtonComponent: React.FC<{ onClick: () => void }>;
+  ButtonProps: any;
   onConfirm: () => void;
   sx?: { [key: string]: string };
 };
 // TODO Maintain a state object of the form field values. Initialize it as their incoming values if present.
 // TODO When the form is submitted, validate the fields first and call the onConfirm callback if all fields are valid.
 
-const EditDialog: React.FC<EditDialogProps> = ({ fields, onClose, sx }) => {
+const EditDialog: React.FC<EditDialogProps> = ({
+  onClose,
+  title,
+  sx,
+  fields,
+  onConfirm,
+  ButtonComponent,
+  ButtonProps,
+}) => {
   const [editState, setEditState] = useState<{ [key: string]: string | number | boolean }>({});
-
-  /*  
-  TODO Yes, but need refactoring.
-  useEffect(() => {
-    setEditState(fields);
-  }, [toEdit]);
-  */
 
   const handleChange = (key: string, value: string | number | boolean) => {
     setEditState((prevState) => ({ ...prevState, [key]: value }));
   };
 
+  // Initial state setup in useEffect to handle incoming props correctly
+  useEffect(() => {
+    const initialState = {};
+    Object.keys(fields).forEach(key => {
+      initialState[key] = fields[key].value;
+    });
+    setEditState(initialState);
+  }, [fields]);  // Depend on `fields` to re-initialize state when `fields` prop changes
+
   return (
-    <Box
-      sx={{
-        li: {
-          listStyleType: 'none',
-        },
-      }}
-    >
-      <ul>
-        {Object.entries(editState).map(([key, value]) => (
-          <li key={key}>
-            {`${key}: `}
-            <input type='text' value={value.toString()} onChange={(e) => handleChange(key, e.target.value)} />
-          </li>
-        ))}
-      </ul>
-      <button onClick={onClose}>Confirm Edit</button>
-    </Box>
+    <Dialog
+      onClose={onClose}
+      title={title}
+      sx={sx}
+      content={
+        <Box
+          sx={{
+            li: {
+              listStyleType: 'none',
+            },
+          }}
+        >
+          <ul>
+            {Object.entries(editState).map(([key, value]) => (
+              <li key={key}>
+                {`${key}: `}
+                <input type='text' value={value.toString()} onChange={(e) => handleChange(key, e.target.value)} />
+              </li>
+            ))}
+          </ul>
+        </Box>}
+      onConfirm={onConfirm}
+      ButtonComponent={ButtonComponent}
+      ButtonProps={ButtonProps}
+    />
   );
 };
 

--- a/src/Dialog/Image/ImageDialog.stories.tsx
+++ b/src/Dialog/Image/ImageDialog.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 // Import Component and related types.
 import ImageDialogComponent, { ImageDialogProps } from './ImageDialog';
 import React from 'react';
+
 // Configure Metadata.
 const meta: Meta = {
   title: 'Dialog/ImageDialog',
@@ -19,9 +20,16 @@ const meta: Meta = {
     references: [],
   },
 };
+
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Configure Component Stories.
+// Sample image URL for testing
+const sampleImageUrl = 'https://fastly.picsum.photos/id/237/200/300.jpg?hmac=TmmQSbShHz9CdQm0NkEjx1Dyh_Y984R9LpNrpvH2D_U';
+
 export const ImageDialog: Story = (args: ImageDialogProps) => <ImageDialogComponent {...args} />;
-ImageDialog.args = {};
+ImageDialog.args = {
+  onClose: () => console.log('Close clicked'),
+  imageSrc: sampleImageUrl,
+  title: 'Sample Image',
+};

--- a/src/Dialog/Image/ImageDialog.tsx
+++ b/src/Dialog/Image/ImageDialog.tsx
@@ -1,13 +1,41 @@
-import React from 'react';
-import Dialog, { CommonDialogProps } from '../Dialog'; // Adjust the import path as necessary
+import React, { useState } from 'react';
+import Dialog, { CommonDialogProps } from '../Dialog';
+import { IconButton } from '@mui/material';
+import { Close } from '@mui/icons-material';
+import Image from 'next/image';
 
-export type ImageDialogProps = CommonDialogProps & {
-  src: string;
+export type ImageDialogProps = {
+  onClose: () => void;
+  imageSrc: string;
+  title?: string;
+  sx?: { [key: string]: string | number };
 };
 
-// TODO: Implement Image component to display the image from src. The ButtonComponent and ButtonProps should be a fill implementation of the image component.
-const ConfirmationDialog: React.FC<ImageDialogProps> = ({ onClose, title, src, sx }) => {
-  return null; //<Dialog {...{ onClose, title, sx }} content={<Image />} />;
+const ImageDialog: React.FC<ImageDialogProps> = ({ onClose, imageSrc, title, sx }) => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleImageClick = () => {
+    setDialogOpen(true);
+  };
+
+  const handleClose = () => {
+    setDialogOpen(false);
+    onClose();
+  };
+
+  return (
+    <Dialog onClose={handleClose} sx={sx} content={dialogOpen ? <Image src={imageSrc} alt={title} style={{ width: '100vw', height: '100vh' }} /> : (
+      <Image src={imageSrc} alt={title} onClick={handleImageClick} style={{ cursor: 'pointer', ...sx }} width={50} height={50} />
+    )} ButtonComponent={({ onClick }) => (
+      <Image src={imageSrc} alt={title} onClick={onClick} style={{ display: 'none' }} width={50} height={50} />
+    )} ButtonProps={{}}>
+      {dialogOpen && (
+        <IconButton onClick={handleClose} sx={{ position: 'absolute', top: '8px', right: '8px', zIndex: 1 }}>
+          <Close />
+        </IconButton>
+      )}
+    </Dialog>
+  );
 };
 
-export default ConfirmationDialog;
+export default ImageDialog;


### PR DESCRIPTION
Re-factor EditDialog, ConfirmationDialog, and ImageDialog using base Dialog component from JRG components
- Extend common dialog props to Edit, Confirmation, and Image dialog allowing button to control open/close state of dialog components wrapped by Dialog wrapper.