### PR TITLE
Don't redirect from home if not logged in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -652,3 +652,4 @@ FodyWeavers.xsd
 # End of https://www.toptal.com/developers/gitignore/api/visualstudio,visualstudiocode,windows,macos,linux,web,node,nextjs
 
 metadata.json
+test.ipynb

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jrgcomponents",
-  "version": "0.0.189",
+  "version": "0.0.191",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jrgcomponents",
-      "version": "0.0.189",
+      "version": "0.0.191",
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.13.3",
@@ -55,7 +55,6 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@esbuild/win32-x64": "^0.24.0",
         "@storybook/addon-actions": "^8.1.4",
         "@storybook/addon-docs": "^8.1.4",
         "@storybook/addon-essentials": "^8.2.9",
@@ -2814,22 +2813,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
-      "integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jrgcomponents",
-  "version": "0.0.190",
+  "version": "0.0.191",
   "description": "Components developed by Jameson R Grieve for use in React/NextJS projects.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -135,7 +135,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@esbuild/win32-x64": "^0.24.0",
     "@storybook/addon-actions": "^8.1.4",
     "@storybook/addon-docs": "^8.1.4",
     "@storybook/addon-essentials": "^8.2.9",

--- a/src/Routing/Auth/Identify.tsx
+++ b/src/Routing/Auth/Identify.tsx
@@ -69,6 +69,7 @@ export default function Identify({
 
   const showEmail = authConfig.authModes.basic || authConfig.authModes.magical;
   const showOAuth = authConfig.authModes.oauth2;
+  // This logic is insufficient
 
   return (
     <AuthCard title='Welcome' description='Please choose an authentication method.'>

--- a/src/Routing/Auth/Identify.tsx
+++ b/src/Routing/Auth/Identify.tsx
@@ -69,7 +69,6 @@ export default function Identify({
 
   const showEmail = authConfig.authModes.basic || authConfig.authModes.magical;
   const showOAuth = authConfig.authModes.oauth2;
-  // This logic is insufficient
 
   return (
     <AuthCard title='Welcome' description='Please choose an authentication method.'>

--- a/src/Routing/Middleware/Hooks.tsx
+++ b/src/Routing/Middleware/Hooks.tsx
@@ -93,7 +93,8 @@ export const useAuth: MiddlewareHook = async (req) => {
           authMode === AuthMode.MagicalAuth &&
           requestedURI.startsWith(process.env.AUTH_WEB) &&
           jwt.length > 0 &&
-          req.nextUrl.pathname !== '/user/manage'
+          req.nextUrl.pathname !== '/user/manage' &&
+          req.nextUrl.pathname !== '/'
         ) {
           console.log(
             `Detected authenticated user attempting to visit non-management page. Redirecting to ${process.env.AUTH_WEB}/manage...`,


### PR DESCRIPTION
It is currently redirecting from `/` if no `jwt` is defined instead of allowing for a landing page. This allows `/` to be ignored from this check in middleware and can be applied per application in `app/page.tsx` like so:

```typescript
import { cookies } from 'next/headers';
import { redirect } from 'next/navigation';
import LandingPage from '@/components/landingpage';

export default function Home() {
  const cookieStore = cookies();
  const isLoggedIn = !!cookieStore.get('jwt')?.value;

  if (isLoggedIn) {
    redirect('/chat');
  }

  return <LandingPage />;
}
```

- Should theoretically solve #20 
- Should also solve #27 