### PR TITLE
Fix: center logo and app name

### DIFF
--- a/src/Head.tsx
+++ b/src/Head.tsx
@@ -1,6 +1,7 @@
 export default function Head() {
   return (
     <head>
+      <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
       <link rel='icon' href='/favicon.ico' sizes='any' />
       <meta name='google-adsense-account' content={process.env.NEXT_PUBLIC_ADSENSE_ACCOUNT ?? ''} />
       <meta property='og:url' content={process.env.NEXT_PUBLIC_APP_URI ?? ''} />

--- a/src/SidebarMain.tsx
+++ b/src/SidebarMain.tsx
@@ -47,12 +47,12 @@ export function SidebarMain({ children, ...props }: React.ComponentProps<typeof 
 // Temporary sidebar Logo until agent selector is implemented
 export function SidebarLogo() {
   return (
-    <div className='flex items-center gap-2 p-0'>
-      <div className='flex items-center justify-center rounded-lg aspect-square size-8 bg-sidebar-primary text-sidebar-primary-foreground'>
+    <div className='flex items-center justify-center gap-2 w-full px-4 md:px-6'>
+      <div className='flex items-center justify-center rounded-lg aspect-square size-8 bg-sidebar-primary text-sidebar-primary-foreground flex-shrink-0'>
         <FaRobot className='size-4' />
       </div>
-      <div className='grid flex-1 text-sm leading-tight text-left'>
-        <span className='font-semibold text-lg truncate'>{process.env.NEXT_PUBLIC_APP_NAME ?? 'App Name'}</span>
+      <div className='text-sm leading-tight text-center w-full hidden md:block group-data-[collapsible=icon]:hidden'>
+        <span className='font-semibold text-lg truncate block'>{process.env.NEXT_PUBLIC_APP_NAME ?? 'App Name'}</span>
       </div>
     </div>
   );


### PR DESCRIPTION
# Fix: center logo and app name

## Description
- Centers the app logo and app name in the sidebar.
- Adds viewport meta tag to improve layout scaling on mobile: